### PR TITLE
Add `toBns` and allow for number arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # biggystring
 
+## Unreleased
+
+- added: New toBns function to convert JS number to big number strings
+
 ## 4.1.3 (2023-01-09)
 
 - Fix library path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: New toBns function to convert JS number to big number strings
+- changed: Implement toBns for all public API to expand argument type support
 
 ## 4.1.3 (2023-01-09)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ function validate(...args: string[]): void {
   }
 }
 
-function add(x1: string, y1: string, base: number = 10): string {
+export function add(x1: string, y1: string, base: number = 10): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
@@ -174,7 +174,7 @@ function add(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-function mul(x1: string, y1: string, base: number = 10): string {
+export function mul(x1: string, y1: string, base: number = 10): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
@@ -188,7 +188,7 @@ function mul(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-function sub(x1: string, y1: string, base: number = 10): string {
+export function sub(x1: string, y1: string, base: number = 10): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
@@ -202,7 +202,7 @@ function sub(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-function div(
+export function div(
   x1: string,
   y1: string,
   precision: number = 0,
@@ -224,7 +224,7 @@ function div(
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-function lt(x1: string, y1: string): boolean {
+export function lt(x1: string, y1: string): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -235,7 +235,7 @@ function lt(x1: string, y1: string): boolean {
   return xBN.lt(yBN)
 }
 
-function lte(x1: string, y1: string): boolean {
+export function lte(x1: string, y1: string): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -246,7 +246,7 @@ function lte(x1: string, y1: string): boolean {
   return xBN.lte(yBN)
 }
 
-function gt(x1: string, y1: string): boolean {
+export function gt(x1: string, y1: string): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -257,7 +257,7 @@ function gt(x1: string, y1: string): boolean {
   return xBN.gt(yBN)
 }
 
-function gte(x1: string, y1: string): boolean {
+export function gte(x1: string, y1: string): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -268,7 +268,7 @@ function gte(x1: string, y1: string): boolean {
   return xBN.gte(yBN)
 }
 
-function eq(x1: string, y1: string): boolean {
+export function eq(x1: string, y1: string): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -279,7 +279,7 @@ function eq(x1: string, y1: string): boolean {
   return xBN.eq(yBN)
 }
 
-function min(x1: string, y1: string, base: number = 10): string {
+export function min(x1: string, y1: string, base: number = 10): string {
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -297,7 +297,7 @@ function min(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-function abs(x1: string, base: number = 10): string {
+export function abs(x1: string, base: number = 10): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, shift } = floatShifts(x1, '0')
   const xBase = isHex(x1) ? 16 : 10
@@ -308,7 +308,7 @@ function abs(x1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-function max(x1: string, y1: string, base: number = 10): string {
+export function max(x1: string, y1: string, base: number = 10): string {
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -392,16 +392,16 @@ function precisionAdjust(
   return out
 }
 
-const floor = (x1: string, precision: number): string =>
+export const floor = (x1: string, precision: number): string =>
   precisionAdjust('floor', x1, precision)
 
-const ceil = (x1: string, precision: number): string =>
+export const ceil = (x1: string, precision: number): string =>
   precisionAdjust('ceil', x1, precision)
 
-const round = (x1: string, precision: number): string =>
+export const round = (x1: string, precision: number): string =>
   precisionAdjust('round', x1, precision)
 
-function toFixed(
+export function toFixed(
   x1: string,
   minPrecision: number = 2,
   maxPrecision: number = 8
@@ -442,7 +442,7 @@ function toFixed(
   return out
 }
 
-function log10(x: string): number {
+export function log10(x: string): number {
   if (!(x.match(/^[0-1]+$/g) !== null)) {
     throw new Error('InvalidLogInputValue: Must be a power of 10')
   }
@@ -453,24 +453,4 @@ function log10(x: string): number {
     throw new Error('InvalidLogInputValue: Must be power of 10.')
   }
   return (x.match(/0/g) || []).length
-}
-
-export {
-  add,
-  sub,
-  mul,
-  div,
-  gt,
-  lt,
-  gte,
-  lte,
-  eq,
-  min,
-  max,
-  log10,
-  toFixed,
-  abs,
-  floor,
-  ceil,
-  round,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ const SCI_NOTATION_REGEX = /^(-?\d*\.?\d*)e((?:\+|-)?\d+)$/
 // Public
 // -----------------------------------------------------------------------------
 
-export function add(x1: string, y1: string, base: number = 10): string {
+export function add(
+  x1: string | number,
+  y1: string | number,
+  base: number = 10
+): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
@@ -30,7 +34,11 @@ export function add(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-export function mul(x1: string, y1: string, base: number = 10): string {
+export function mul(
+  x1: string | number,
+  y1: string | number,
+  base: number = 10
+): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
@@ -44,7 +52,11 @@ export function mul(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-export function sub(x1: string, y1: string, base: number = 10): string {
+export function sub(
+  x1: string | number,
+  y1: string | number,
+  base: number = 10
+): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
@@ -59,8 +71,8 @@ export function sub(x1: string, y1: string, base: number = 10): string {
 }
 
 export function div(
-  x1: string,
-  y1: string,
+  x1: string | number,
+  y1: string | number,
   precision: number = 0,
   base: number = 10
 ): string {
@@ -80,7 +92,7 @@ export function div(
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-export function lt(x1: string, y1: string): boolean {
+export function lt(x1: string | number, y1: string | number): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -91,7 +103,7 @@ export function lt(x1: string, y1: string): boolean {
   return xBN.lt(yBN)
 }
 
-export function lte(x1: string, y1: string): boolean {
+export function lte(x1: string | number, y1: string | number): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -102,7 +114,7 @@ export function lte(x1: string, y1: string): boolean {
   return xBN.lte(yBN)
 }
 
-export function gt(x1: string, y1: string): boolean {
+export function gt(x1: string | number, y1: string | number): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -113,7 +125,7 @@ export function gt(x1: string, y1: string): boolean {
   return xBN.gt(yBN)
 }
 
-export function gte(x1: string, y1: string): boolean {
+export function gte(x1: string | number, y1: string | number): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -124,7 +136,7 @@ export function gte(x1: string, y1: string): boolean {
   return xBN.gte(yBN)
 }
 
-export function eq(x1: string, y1: string): boolean {
+export function eq(x1: string | number, y1: string | number): boolean {
   let { x, y } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -135,7 +147,11 @@ export function eq(x1: string, y1: string): boolean {
   return xBN.eq(yBN)
 }
 
-export function min(x1: string, y1: string, base: number = 10): string {
+export function min(
+  x1: string | number,
+  y1: string | number,
+  base: number = 10
+): string {
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -153,7 +169,7 @@ export function min(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-export function abs(x1: string, base: number = 10): string {
+export function abs(x1: string | number, base: number = 10): string {
   if (base !== 10 && base !== 16) throw new Error('Unsupported base')
   let { x, shift } = floatShifts(x1, '0')
   const xBase = isHex(x1) ? 16 : 10
@@ -164,7 +180,11 @@ export function abs(x1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-export function max(x1: string, y1: string, base: number = 10): string {
+export function max(
+  x1: string | number,
+  y1: string | number,
+  base: number = 10
+): string {
   let { x, y, shift } = floatShifts(x1, y1)
   const xBase = isHex(x) ? 16 : 10
   const yBase = isHex(y) ? 16 : 10
@@ -182,13 +202,13 @@ export function max(x1: string, y1: string, base: number = 10): string {
   return base === 10 ? out : out.replace(/^(-)?/, '$10x')
 }
 
-export const floor = (x1: string, precision: number): string =>
+export const floor = (x1: string | number, precision: number): string =>
   precisionAdjust('floor', x1, precision)
 
-export const ceil = (x1: string, precision: number): string =>
+export const ceil = (x1: string | number, precision: number): string =>
   precisionAdjust('ceil', x1, precision)
 
-export const round = (x1: string, precision: number): string =>
+export const round = (x1: string | number, precision: number): string =>
   precisionAdjust('round', x1, precision)
 
 export function toBns(n: number | string): string {
@@ -208,14 +228,14 @@ export function toBns(n: number | string): string {
 }
 
 export function toFixed(
-  x1: string,
+  x1: string | number,
   minPrecision: number = 2,
   maxPrecision: number = 8
 ): string {
-  validate(x1)
+  let x = toBns(x1)
+
   let negative = false
   let out = ''
-  let x = x1
 
   if (x.includes('-')) {
     negative = true
@@ -301,13 +321,12 @@ function cropHex(x: string): string {
 // Takes two floating point (base 10) numbers and finds the multiplier needed to make them both
 // operable as a integer
 function floatShifts(
-  xStart: string,
-  yStart: string,
+  xStart: string | number,
+  yStart: string | number,
   moreShift?: number
 ): ShiftPair {
-  let x = xStart
-  let y = yStart
-  validate(x, y)
+  let x = toBns(xStart)
+  let y = toBns(yStart)
   let xPos: number = x.indexOf('.')
   let yPos: number = y.indexOf('.')
 
@@ -365,7 +384,8 @@ function floatShifts(
   }
 }
 
-function isHex(x: string): boolean {
+function isHex(x1: string | number): boolean {
+  const x = toBns(x1)
   if (
     x.startsWith('0x') ||
     x.startsWith('-0x') ||
@@ -384,13 +404,13 @@ function isHex(x: string): boolean {
 
 function precisionAdjust(
   type: 'ceil' | 'floor' | 'round',
-  x1: string,
+  x1: string | number,
   precision: number = 0
 ): string {
-  validate(x1)
+  let x = toBns(x1)
+
   let negative = false
   let out = ''
-  let x = x1
 
   if (x.includes('-')) {
     negative = true

--- a/test/biggystring.test.ts
+++ b/test/biggystring.test.ts
@@ -21,6 +21,7 @@ import {
   mul,
   round,
   sub,
+  toBns,
   toFixed,
 } from '../src/index'
 
@@ -191,6 +192,93 @@ describe('div', function () {
   })
   it('resolve negative numbers in base 16', function () {
     assert.equal(div('-60830', '1', 0, 16), '-0xed9e')
+  })
+})
+
+describe('toBns', function () {
+  it('regular number', function () {
+    assert.equal(toBns(123), '123')
+  })
+  it('scientific notation: regular numbers', function () {
+    const numStr = '5e0'
+    assert.equal(toBns(numStr), '5')
+  })
+  it('scientific notation: big integer base', function () {
+    const big = 3000000000000000000000
+    const bigStr = big.toString()
+    assert.equal(bigStr, '3e+21')
+    assert.equal(toBns(big), '3000000000000000000000')
+    assert.equal(toBns(bigStr), '3000000000000000000000')
+  })
+  it('scientific notation: small integer base', function () {
+    const small = 0.000000000000000000003
+    const smallStr = small.toString()
+    assert.equal(smallStr, '3e-21')
+    assert.equal(toBns(small), '0.000000000000000000003')
+    assert.equal(toBns(smallStr), '0.000000000000000000003')
+  })
+  it('scientific notation: big negative base', function () {
+    const big = -3000000000000000000000
+    const bigStr = big.toString()
+    assert.equal(bigStr, '-3e+21')
+    assert.equal(toBns(big), '-3000000000000000000000')
+    assert.equal(toBns(bigStr), '-3000000000000000000000')
+  })
+  it('scientific notation: small negative base', function () {
+    const small = -0.000000000000000000003
+    const smallStr = small.toString()
+    assert(smallStr, '-3e-21')
+    assert.equal(toBns(small), '-0.000000000000000000003')
+    assert.equal(toBns(smallStr), '-0.000000000000000000003')
+  })
+  it('scientific notation: big decimal base', function () {
+    const decimal = 312000000000000000000000
+    const decimalStr = decimal.toString()
+    assert.equal(decimalStr, '3.12e+23')
+    assert.equal(toBns(decimal), '312000000000000000000000')
+    assert.equal(toBns(decimalStr), '312000000000000000000000')
+  })
+  it('scientific notation: small decimal base', function () {
+    const small = 0.000000000000000000000312
+    const smallStr = small.toString()
+    assert(smallStr, '3.12e-23')
+    assert.equal(toBns(small), '0.000000000000000000000312')
+    assert.equal(toBns(smallStr), '0.000000000000000000000312')
+  })
+  it('scientific notation: big negative decimal base', function () {
+    const small = -312000000000000000000000
+    const smallStr = small.toString()
+    assert(smallStr, '-3.12e+23')
+    assert.equal(toBns(small), '-312000000000000000000000')
+    assert.equal(toBns(smallStr), '-312000000000000000000000')
+  })
+  it('scientific notation: small negative decimal base', function () {
+    const small = -0.000000000000000000000312
+    const smallStr = small.toString()
+    assert(smallStr, '-3.12e-23')
+    assert.equal(toBns(small), '-0.000000000000000000000312')
+    assert.equal(toBns(smallStr), '-0.000000000000000000000312')
+  })
+  it('scientific notation: long decimal base', function () {
+    const longDecimalSciNo = '-1.2345678911121314151617181920e-12'
+    assert.equal(
+      toBns(longDecimalSciNo),
+      '-0.000000000001234567891112131415161718192'
+    )
+  })
+  it('scientific notation: invalid numbers', function () {
+    assert.throws(
+      () => toBns('3.2.0e12'),
+      `Invalid number: more than one decimal point '3.2.0e12'`
+    )
+    assert.throws(
+      () => toBns('3x0e12'),
+      `Invalid number: non-number characters '3x0e12'`
+    )
+    assert.throws(
+      () => toBns('3e1.2'),
+      `Invalid number: non-number characters '3e1.2'`
+    )
   })
 })
 

--- a/test/biggystring.test.ts
+++ b/test/biggystring.test.ts
@@ -24,30 +24,13 @@ import {
   toFixed,
 } from '../src/index'
 
-const bns = {
-  add,
-  sub,
-  mul,
-  log10,
-  div,
-  toFixed,
-  lt,
-  lte,
-  gt,
-  gte,
-  eq,
-  min,
-  max,
-  abs,
-}
-
 describe('add', function () {
   it('32 + 10 = 42', function () {
-    assert.equal(bns.add('32', '10'), '42')
+    assert.equal(add('32', '10'), '42')
   })
   it('very big num', function () {
     assert.equal(
-      bns.add(
+      add(
         '1234000000000000000000000000000000001234',
         '4321000000000000000000000000000000004321'
       ),
@@ -55,23 +38,23 @@ describe('add', function () {
     )
   })
   it('0x100 + 10 = 266', function () {
-    assert.equal(bns.add('0x100', '10'), '266')
+    assert.equal(add('0x100', '10'), '266')
   })
   it('0x100 + 0x10 = 272', function () {
-    assert.equal(bns.add('0x100', '0x10'), '272')
+    assert.equal(add('0x100', '0x10'), '272')
   })
   it('0x100 + -0x10 = 240', function () {
-    assert.equal(bns.add('0x100', '-0x10'), '240')
+    assert.equal(add('0x100', '-0x10'), '240')
   })
   it('0x100 + 0x10 = 0x110', function () {
-    assert.equal(bns.add('0x100', '0x10', 16), '0x110')
+    assert.equal(add('0x100', '0x10', 16), '0x110')
   })
   it('32.01 + 10.2 = 42.21', function () {
-    assert.equal(bns.add('32.01', '10.2'), '42.21')
+    assert.equal(add('32.01', '10.2'), '42.21')
   })
   it('very big float', function () {
     assert.equal(
-      bns.add(
+      add(
         '100000.1234000000000000000000000000000000001234',
         '4321000000000000000000000000000000004321.000001'
       ),
@@ -80,7 +63,7 @@ describe('add', function () {
   })
   it('very big negative float', function () {
     assert.equal(
-      bns.add(
+      add(
         '1000000000000000001.9876000000000000000000000000000000009876',
         '-001.4321000000000000000000000000000000004321'
       ),
@@ -88,17 +71,17 @@ describe('add', function () {
     )
   })
   it('resolve negative numbers in base 16', function () {
-    assert.equal(bns.add('-60830', '0', 16), '-0xed9e')
+    assert.equal(add('-60830', '0', 16), '-0xed9e')
   })
 })
 
 describe('sub', function () {
   it('32 - 10 = 22', function () {
-    assert.equal(bns.sub('32', '10'), '22')
+    assert.equal(sub('32', '10'), '22')
   })
   it('very big num', function () {
     assert.equal(
-      bns.sub(
+      sub(
         '9876000000000000000000000000000000009876',
         '4321000000000000000000000000000000004321'
       ),
@@ -106,23 +89,23 @@ describe('sub', function () {
     )
   })
   it('0x100 1 10 = 246', function () {
-    assert.equal(bns.sub('0x100', '10'), '246')
+    assert.equal(sub('0x100', '10'), '246')
   })
   it('0x100 - 0x10 = 240', function () {
-    assert.equal(bns.sub('0x100', '0x10'), '240')
+    assert.equal(sub('0x100', '0x10'), '240')
   })
   it('0x100 - -0x10 = 272', function () {
-    assert.equal(bns.sub('0x100', '-0x10'), '272')
+    assert.equal(sub('0x100', '-0x10'), '272')
   })
   it('0x100 - 0x10 = 0xf0', function () {
-    assert.equal(bns.sub('0x100', '0x10', 16), '0xf0')
+    assert.equal(sub('0x100', '0x10', 16), '0xf0')
   })
   it('32.01 - 10.2 = 21.81', function () {
-    assert.equal(bns.sub('32.01', '10.2'), '21.81')
+    assert.equal(sub('32.01', '10.2'), '21.81')
   })
   it('very big float', function () {
     assert.equal(
-      bns.sub(
+      sub(
         '1000000000000000001.9876000000000000000000000000000000009876',
         '001.4321000000000000000000000000000000004321'
       ),
@@ -130,100 +113,100 @@ describe('sub', function () {
     )
   })
   it('resolve negative numbers in base 16', function () {
-    assert.equal(bns.sub('-60830', '0', 16), '-0xed9e')
+    assert.equal(sub('-60830', '0', 16), '-0xed9e')
   })
 })
 
 describe('mul', function () {
   it('4 * 5 = 20', function () {
-    assert.equal(bns.mul('4', '5'), '20')
+    assert.equal(mul('4', '5'), '20')
   })
   it('very big num', function () {
     assert.equal(
-      bns.mul('400000000000000000000000000', '5'),
+      mul('400000000000000000000000000', '5'),
       '2000000000000000000000000000'
     )
   })
   it('very small num', function () {
     assert.equal(
-      bns.mul('1234567890123456.123', '.00000000000000000000001'),
+      mul('1234567890123456.123', '.00000000000000000000001'),
       '0.00000001234567890123456123'
     )
   })
   it('resolve negative numbers in base 16', function () {
-    assert.equal(bns.mul('-60830', '1', 16), '-0xed9e')
+    assert.equal(mul('-60830', '1', 16), '-0xed9e')
   })
 })
 
 describe('div', function () {
   it('-411 / 100000 = -0.00411', function () {
-    assert.equal(bns.div('-411', '100000', 18), '-0.00411')
+    assert.equal(div('-411', '100000', 18), '-0.00411')
   })
   it('20 / 5 = 4', function () {
-    assert.equal(bns.div('20', '5'), '4')
+    assert.equal(div('20', '5'), '4')
   })
   it('20.0 / 5.0 = 4', function () {
-    assert.equal(bns.div('20.0', '5.0'), '4')
+    assert.equal(div('20.0', '5.0'), '4')
   })
   it('20.0 / 5 = 4', function () {
-    assert.equal(bns.div('20.0', '5'), '4')
+    assert.equal(div('20.0', '5'), '4')
   })
   it('20 / 5.0 = 4', function () {
-    assert.equal(bns.div('20', '5.0'), '4')
+    assert.equal(div('20', '5.0'), '4')
   })
   it('10 / 3 = 3', function () {
-    assert.equal(bns.div('10', '3'), '3')
+    assert.equal(div('10', '3'), '3')
   })
   it('10 / 3 = 3.33333 (precision 5)', function () {
-    assert.equal(bns.div('10', '3', 5), '3.33333')
+    assert.equal(div('10', '3', 5), '3.33333')
   })
   it('very big num', function () {
     assert.equal(
-      bns.div('400000000000000000000000000', '5'),
+      div('400000000000000000000000000', '5'),
       '80000000000000000000000000'
     )
   })
   it('very big float', function () {
     assert.equal(
-      bns.div('800000000000000000000000000.0000000000000000008', '2'),
+      div('800000000000000000000000000.0000000000000000008', '2'),
       '400000000000000000000000000'
     )
   })
   it('very big float (precision 9, base 10)', function () {
     assert.equal(
-      bns.div('800000000000000000000000000.000000008', '2', 9, 10),
+      div('800000000000000000000000000.000000008', '2', 9, 10),
       '400000000000000000000000000.000000004'
     )
   })
   it('very small num', function () {
     assert.equal(
-      bns.div('1234567890123456.123', '.00000000000000000000001'),
+      div('1234567890123456.123', '.00000000000000000000001'),
       '123456789012345612300000000000000000000'
     )
   })
   it('Check error with hex output', function () {
     assert.throws(() => {
-      bns.div('10', '3', 5, 16)
+      div('10', '3', 5, 16)
     })
   })
   it('resolve negative numbers in base 16', function () {
-    assert.equal(bns.div('-60830', '1', 0, 16), '-0xed9e')
+    assert.equal(div('-60830', '1', 0, 16), '-0xed9e')
   })
 })
 
 describe('less than', function () {
   it('15 < 20 = True', function () {
-    assert.equal(bns.lt('15', '20'), true)
+    assert.equal(lt('15', '20'), true)
   })
   it('20 < 15 = False', function () {
-    assert.equal(bns.lt('20', '15'), false)
+    assert.equal(lt('20', '15'), false)
   })
   it('20 < 20 = False', function () {
-    assert.equal(bns.lt('20', '20'), false)
+    assert.equal(lt('20', '20'), false)
   })
   it('Big num true', function () {
     assert.equal(
-      bns.lt(
+      lt(
         '4321000000000000000000000000000000004320',
         '4321000000000000000000000000000000004321'
       ),
@@ -232,7 +215,7 @@ describe('less than', function () {
   })
   it('Big num false', function () {
     assert.equal(
-      bns.lt(
+      lt(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004321'
       ),
@@ -241,7 +224,7 @@ describe('less than', function () {
   })
   it('Big num eq false', function () {
     assert.equal(
-      bns.lt(
+      lt(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004322'
       ),
@@ -250,7 +233,7 @@ describe('less than', function () {
   })
   it('Big float true', function () {
     assert.equal(
-      bns.lt(
+      lt(
         '1.004321000000000000000000000000000000004320',
         '1.004321000000000000000000000000000000004321'
       ),
@@ -259,7 +242,7 @@ describe('less than', function () {
   })
   it('Big float false', function () {
     assert.equal(
-      bns.lt(
+      lt(
         '10000000000000000.4321000000000000000000000000000000004322',
         '10000000000000000.4321000000000000000000000000000000004321'
       ),
@@ -268,7 +251,7 @@ describe('less than', function () {
   })
   it('Big float eq false', function () {
     assert.equal(
-      bns.lt(
+      lt(
         '1234.4321000000000000000000000000000000004322',
         '0000001234.43210000000000000000000000000000000043220000'
       ),
@@ -279,17 +262,17 @@ describe('less than', function () {
 
 describe('greater than', function () {
   it('15 > 20 = false', function () {
-    assert.equal(bns.gt('15', '20'), false)
+    assert.equal(gt('15', '20'), false)
   })
   it('20 > 15 = true', function () {
-    assert.equal(bns.gt('20', '15'), true)
+    assert.equal(gt('20', '15'), true)
   })
   it('20 > 20 = false', function () {
-    assert.equal(bns.gt('20', '20'), false)
+    assert.equal(gt('20', '20'), false)
   })
   it('Big num false', function () {
     assert.equal(
-      bns.gt(
+      gt(
         '4321000000000000000000000000000000004320',
         '4321000000000000000000000000000000004321'
       ),
@@ -298,7 +281,7 @@ describe('greater than', function () {
   })
   it('Big num true', function () {
     assert.equal(
-      bns.gt(
+      gt(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004321'
       ),
@@ -307,7 +290,7 @@ describe('greater than', function () {
   })
   it('Big num eq false', function () {
     assert.equal(
-      bns.gt(
+      gt(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004322'
       ),
@@ -316,7 +299,7 @@ describe('greater than', function () {
   })
   it('Big float eq false', function () {
     assert.equal(
-      bns.gt(
+      gt(
         '1234.4321000000000000000000000000000000004322',
         '0000001234.43210000000000000000000000000000000043220000'
       ),
@@ -325,7 +308,7 @@ describe('greater than', function () {
   })
   it('Big float true', function () {
     assert.equal(
-      bns.gt(
+      gt(
         '1234.4321000000000000000001000000000000004322',
         '0000001234.43210000000000000000000000000000000043220000'
       ),
@@ -334,7 +317,7 @@ describe('greater than', function () {
   })
   it('Big float false', function () {
     assert.equal(
-      bns.gt(
+      gt(
         '1234.4321000000000000000000000000000000004322',
         '0000001234.43210000000000000000000000000000000043220001'
       ),
@@ -345,17 +328,17 @@ describe('greater than', function () {
 
 describe('less than equal', function () {
   it('15 <= 20 = True', function () {
-    assert.equal(bns.lte('15', '20'), true)
+    assert.equal(lte('15', '20'), true)
   })
   it('20 <= 15 = False', function () {
-    assert.equal(bns.lte('20', '15'), false)
+    assert.equal(lte('20', '15'), false)
   })
   it('20 <= 20 = true', function () {
-    assert.equal(bns.lte('20', '20'), true)
+    assert.equal(lte('20', '20'), true)
   })
   it('Big num true', function () {
     assert.equal(
-      bns.lte(
+      lte(
         '4321000000000000000000000000000000004320',
         '4321000000000000000000000000000000004321'
       ),
@@ -364,7 +347,7 @@ describe('less than equal', function () {
   })
   it('Big num false', function () {
     assert.equal(
-      bns.lte(
+      lte(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004321'
       ),
@@ -373,7 +356,7 @@ describe('less than equal', function () {
   })
   it('Big num eq true', function () {
     assert.equal(
-      bns.lte(
+      lte(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004322'
       ),
@@ -382,7 +365,7 @@ describe('less than equal', function () {
   })
   it('Big float eq true', function () {
     assert.equal(
-      bns.lte(
+      lte(
         '1234.4321000000000000000000000000000000004322',
         '0000001234.43210000000000000000000000000000000043220000'
       ),
@@ -391,7 +374,7 @@ describe('less than equal', function () {
   })
   it('Big float false', function () {
     assert.equal(
-      bns.lte(
+      lte(
         '1234.4321000000000000000001000000000000004322',
         '0000001234.43210000000000000000000000000000000043220000'
       ),
@@ -400,7 +383,7 @@ describe('less than equal', function () {
   })
   it('Big float true', function () {
     assert.equal(
-      bns.lte(
+      lte(
         '1234.4321000000000000000000000000000000004322',
         '0000001234.43210000000000000000000000000000000043220001'
       ),
@@ -411,17 +394,17 @@ describe('less than equal', function () {
 
 describe('greater than equal', function () {
   it('15 >= 20 = false', function () {
-    assert.equal(bns.gte('15', '20'), false)
+    assert.equal(gte('15', '20'), false)
   })
   it('20 >= 15 = true', function () {
-    assert.equal(bns.gte('20', '15'), true)
+    assert.equal(gte('20', '15'), true)
   })
   it('20 >= 20 = true', function () {
-    assert.equal(bns.gte('20', '15'), true)
+    assert.equal(gte('20', '15'), true)
   })
   it('Big num false', function () {
     assert.equal(
-      bns.gte(
+      gte(
         '4321000000000000000000000000000000004320',
         '4321000000000000000000000000000000004321'
       ),
@@ -430,7 +413,7 @@ describe('greater than equal', function () {
   })
   it('Big num true', function () {
     assert.equal(
-      bns.gte(
+      gte(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004321'
       ),
@@ -439,7 +422,7 @@ describe('greater than equal', function () {
   })
   it('Big num eq true', function () {
     assert.equal(
-      bns.gte(
+      gte(
         '4321000000000000000000000000000000004322',
         '4321000000000000000000000000000000004322'
       ),
@@ -448,7 +431,7 @@ describe('greater than equal', function () {
   })
   it('Big float eq true', function () {
     assert.equal(
-      bns.gte(
+      gte(
         '1234.4321000000000000000000000000000000004322',
         '0000001234.43210000000000000000000000000000000043220000'
       ),
@@ -457,7 +440,7 @@ describe('greater than equal', function () {
   })
   it('Big float true', function () {
     assert.equal(
-      bns.gte(
+      gte(
         '1234.4321000000000000000001000000000000004322',
         '0000001234.43210000000000000000000000000000000043220000'
       ),
@@ -466,7 +449,7 @@ describe('greater than equal', function () {
   })
   it('Big float false', function () {
     assert.equal(
-      bns.gte(
+      gte(
         '1234.4321000000000000000000000000000000004322',
         '0000001234.43210000000000000000000000000000000043220001'
       ),
@@ -477,52 +460,52 @@ describe('greater than equal', function () {
 
 describe('equal', function () {
   it('15 == 20 = false', function () {
-    assert.equal(bns.eq('15', '20'), false)
+    assert.equal(eq('15', '20'), false)
   })
   it('20 == 15 = false', function () {
-    assert.equal(bns.eq('20', '15'), false)
+    assert.equal(eq('20', '15'), false)
   })
   it('20 == 20 = true', function () {
-    assert.equal(bns.eq('20', '20'), true)
+    assert.equal(eq('20', '20'), true)
   })
   it('00020 == 20 = true', function () {
-    assert.equal(bns.eq('00020', '20'), true)
+    assert.equal(eq('00020', '20'), true)
   })
   it('00020 == 20.000 = true', function () {
-    assert.equal(bns.eq('00020', '20.000'), true)
+    assert.equal(eq('00020', '20.000'), true)
   })
   it('00020.000000001 == 20.000 = false', function () {
-    assert.equal(bns.eq('00020.000000001', '20.000'), false)
+    assert.equal(eq('00020.000000001', '20.000'), false)
   })
   it('123456789.12345 == 0x1001 => Error', function () {
     assert.throws(() => {
-      bns.eq('123456789.12345', '0x1001')
+      eq('123456789.12345', '0x1001')
     })
   })
 })
 
 describe('max', function () {
   it('max(100, 1000) => 1000', function () {
-    assert.equal(bns.max('100', '1000'), '1000')
+    assert.equal(max('100', '1000'), '1000')
   })
   it('max(2000, 100) => 2000', function () {
-    assert.equal(bns.max('2000', '100'), '2000')
+    assert.equal(max('2000', '100'), '2000')
   })
   it('max(3000, 3000) => 3000', function () {
-    assert.equal(bns.max('3000', '3000'), '3000')
+    assert.equal(max('3000', '3000'), '3000')
   })
   it('max(0x100, 255) => 256', function () {
-    assert.equal(bns.max('0x100', '255'), '256')
+    assert.equal(max('0x100', '255'), '256')
   })
   it('max(255, 0x100) => 256', function () {
-    assert.equal(bns.max('255', '0x100'), '256')
+    assert.equal(max('255', '0x100'), '256')
   })
   it('max(257, 0x100, 16) => 0x101', function () {
-    assert.equal(bns.max('257', '0x100', 16), '0x101')
+    assert.equal(max('257', '0x100', 16), '0x101')
   })
   it('very big num', function () {
     assert.equal(
-      bns.max(
+      max(
         '9876000000000000000000000000000000000002',
         '9876000000000000000000000000000000000001'
       ),
@@ -530,35 +513,35 @@ describe('max', function () {
     )
   })
   it('max(100.001, 1000.0) => 1000', function () {
-    assert.equal(bns.max('100.001', '1000'), '1000')
+    assert.equal(max('100.001', '1000'), '1000')
   })
   it('max(100123.001, 1000.01) => 1000', function () {
-    assert.equal(bns.max('100123.001', '1000.01'), '100123.001')
+    assert.equal(max('100123.001', '1000.01'), '100123.001')
   })
 })
 
 describe('min', function () {
   it('min(100, 1000) => 100', function () {
-    assert.equal(bns.min('100', '1000'), '100')
+    assert.equal(min('100', '1000'), '100')
   })
   it('min(2000, 100) => 100', function () {
-    assert.equal(bns.min('1000', '100'), '100')
+    assert.equal(min('1000', '100'), '100')
   })
   it('min(3000, 3000) => 3000', function () {
-    assert.equal(bns.min('3000', '3000'), '3000')
+    assert.equal(min('3000', '3000'), '3000')
   })
   it('min(0x100, 255) => 255', function () {
-    assert.equal(bns.min('0x100', '255'), '255')
+    assert.equal(min('0x100', '255'), '255')
   })
   it('min(255, 0x100) => 255', function () {
-    assert.equal(bns.min('255', '0x100'), '255')
+    assert.equal(min('255', '0x100'), '255')
   })
   it('min(257, 0x100, 16) => 0x100', function () {
-    assert.equal(bns.min('257', '0x100', 16), '0x100')
+    assert.equal(min('257', '0x100', 16), '0x100')
   })
   it('very big num', function () {
     assert.equal(
-      bns.min(
+      min(
         '9876000000000000000000000000000000000002',
         '9876000000000000000000000000000000000001'
       ),
@@ -566,105 +549,105 @@ describe('min', function () {
     )
   })
   it('min(100.001, 1000.0) => 1000', function () {
-    assert.equal(bns.min('100.001', '1000'), '100.001')
+    assert.equal(min('100.001', '1000'), '100.001')
   })
   it('min(100123.001, 1000.01) => 1000', function () {
-    assert.equal(bns.min('100123.001', '1000.01'), '1000.01')
+    assert.equal(min('100123.001', '1000.01'), '1000.01')
   })
 })
 
 describe('abs', function () {
   it('abs("1") => "1")', function () {
-    assert.equal(bns.abs('1'), '1')
+    assert.equal(abs('1'), '1')
   })
   it('abs("-1") => "1")', function () {
-    assert.equal(bns.abs('-1'), '1')
+    assert.equal(abs('-1'), '1')
   })
   it('abs("-1.123") => "1.123")', function () {
-    assert.equal(bns.abs('-1.123'), '1.123')
+    assert.equal(abs('-1.123'), '1.123')
   })
   it('abs("-.123456789012345") => "0.123456789012345")', function () {
-    assert.equal(bns.abs('-.123456789012345'), '0.123456789012345')
+    assert.equal(abs('-.123456789012345'), '0.123456789012345')
   })
   it('abs(".123456789012345") => "0.123456789012345")', function () {
-    assert.equal(bns.abs('.123456789012345'), '0.123456789012345')
+    assert.equal(abs('.123456789012345'), '0.123456789012345')
   })
   it('abs("-0x11") => "17")', function () {
-    assert.equal(bns.abs('-0x11'), '17')
+    assert.equal(abs('-0x11'), '17')
   })
   it('abs("-0x11", 16) => "0x11")', function () {
-    assert.equal(bns.abs('-0x11', 16), '0x11')
+    assert.equal(abs('-0x11', 16), '0x11')
   })
 })
 
 describe('toFixed', function () {
   it('toFixed("100", 2) => 100.00', function () {
-    assert.equal(bns.toFixed('100', 2), '100.00')
+    assert.equal(toFixed('100', 2), '100.00')
   })
   it('toFixed("100.123", 2) => 100.12', function () {
-    assert.equal(bns.toFixed('100.123', 2), '100.123')
+    assert.equal(toFixed('100.123', 2), '100.123')
   })
   it('toFixed("00100.123", 2) => 100.12', function () {
-    assert.equal(bns.toFixed('100.123', 2), '100.123')
+    assert.equal(toFixed('100.123', 2), '100.123')
   })
   it('toFixed("00100.12300", 2) => 100.12', function () {
-    assert.equal(bns.toFixed('100.123', 2), '100.123')
+    assert.equal(toFixed('100.123', 2), '100.123')
   })
   it('toFixed("00100.12300", 2) => 100.12', function () {
-    assert.equal(bns.toFixed('100.1', 2), '100.10')
+    assert.equal(toFixed('100.1', 2), '100.10')
   })
   it('toFixed("00100", 5) => 100.00000', function () {
-    assert.equal(bns.toFixed('00100', 5), '100.00000')
+    assert.equal(toFixed('00100', 5), '100.00000')
   })
   it('toFixed("00100.12345678", 5, 7) => 100.12345678', function () {
-    assert.equal(bns.toFixed('00100.12345678', 5, 7), '100.1234567')
+    assert.equal(toFixed('00100.12345678', 5, 7), '100.1234567')
   })
   it('toFixed("00100.12345678", 5, 8) => 100.1234568', function () {
-    assert.equal(bns.toFixed('00100.12345678', 5, 8), '100.12345678')
+    assert.equal(toFixed('00100.12345678', 5, 8), '100.12345678')
   })
   it('toFixed("00100.12345678", 5, 6) => 100.123456', function () {
-    assert.equal(bns.toFixed('00100.12345678', 5, 6), '100.123456')
+    assert.equal(toFixed('00100.12345678', 5, 6), '100.123456')
   })
   it('toFixed("1.0", 1, 6) => "1.0"', function () {
-    assert.equal(bns.toFixed('1.0', 1, 6), '1.0')
+    assert.equal(toFixed('1.0', 1, 6), '1.0')
   })
   it('toFixed("0", 0, 6) => "0"', function () {
-    assert.equal(bns.toFixed('0', 0, 6), '0')
+    assert.equal(toFixed('0', 0, 6), '0')
   })
   it('toFixed("00", 0, 6) => "0"', function () {
-    assert.equal(bns.toFixed('00', 0, 6), '0')
+    assert.equal(toFixed('00', 0, 6), '0')
   })
   it('toFixed("-1.0", 1, 6) => "-1.0"', function () {
-    assert.equal(bns.toFixed('-1.0', 1, 6), '-1.0')
+    assert.equal(toFixed('-1.0', 1, 6), '-1.0')
   })
   it('toFixed("-00100.12345678", 5, 6) => -100.123456', function () {
-    assert.equal(bns.toFixed('-00100.12345678', 5, 6), '-100.123456')
+    assert.equal(toFixed('-00100.12345678', 5, 6), '-100.123456')
   })
   it('toFixed("-00100.12345678", 0, 0) => -100', function () {
-    assert.equal(bns.toFixed('-00100.12345678', 0, 0), '-100')
+    assert.equal(toFixed('-00100.12345678', 0, 0), '-100')
   })
 })
 
 describe('log10', function () {
   it('100 => 2', function () {
-    assert.equal(bns.log10('100'), 2)
+    assert.equal(log10('100'), 2)
   })
   it('100000000000000000000 => 20', function () {
-    assert.equal(bns.log10('100000000000000000000'), 20)
+    assert.equal(log10('100000000000000000000'), 20)
   })
   it('100000000000000001000 => Error', function () {
     assert.throws(() => {
-      bns.log10('100000000000000001000')
+      log10('100000000000000001000')
     })
   })
   it('3000000000000000000 => Error', function () {
     assert.throws(() => {
-      bns.log10('3000000000000000000')
+      log10('3000000000000000000')
     })
   })
   it('00100000000000000001000 => Error', function () {
     assert.throws(() => {
-      bns.log10('00100000000000000001000')
+      log10('00100000000000000001000')
     })
   })
 })


### PR DESCRIPTION
### CHANGELOG

- added: New `toBns` function to convert JS number to big number strings
- changed: Implement `toBns` for all public API to expand argument type support

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205419647873859